### PR TITLE
configure.ac: drop AC_USE_SYSTEM_EXTENSIONS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,6 @@ AC_INIT([xlibre-xf86-input-mouse],
 AC_CONFIG_SRCDIR([Makefile.am])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR(.)
-AC_USE_SYSTEM_EXTENSIONS
 
 # Initialize Automake
 AM_INIT_AUTOMAKE([foreign dist-xz])


### PR DESCRIPTION
we don't (and don't want to) rely on system specific language extensions.